### PR TITLE
Event Page Footer Display Correction #119

### DIFF
--- a/styles/events.css
+++ b/styles/events.css
@@ -10,6 +10,7 @@
 #upcomingEvents {
     padding: 80px 50px 30px 50px;
     background-color: #fff;
+    box-shadow: 1px 1px 20px #000;
 }
 
 #upcomingEvents h1 {

--- a/styles/events.css
+++ b/styles/events.css
@@ -1,7 +1,3 @@
-body.events {
-    background-color: #fff;
-}
-
 /* not currently in use, may become in use again in the future with the implementation of a calendar */
 #calendar {
     height: 800px;
@@ -12,10 +8,7 @@ body.events {
 }
 
 #upcomingEvents {
-    position: absolute;
-    margin-left: 54px;
-    margin-top: 80px;
-    margin-right: 210px;
+    padding: 80px 50px 30px 50px;
     background-color: #fff;
 }
 
@@ -89,7 +82,6 @@ body.events {
     font-weight: lighter;
     margin:0 0 0 0;
     font-size: 15px;
-    width: 1250px;
     line-height: 30px;
     color: #434344;
 }


### PR DESCRIPTION
* removed the position absolute from the events div tag (#upcomingEvents) so that the footer gets pushed below the events instead of overlapping
* changed the margin on the events div tag (#upcomingEvents) to padding so that it takes up the entire width instead of having a border
* removed the specified width on event paragraphs so that it doesn't hide the right edge of text when the window is resized but still hides the bottom part so that it doesn't expand outside the height of each event.
* added a box shadow to events div tag (#upcomingEvents) to match the rest of the website